### PR TITLE
Fixed ubuntu version

### DIFF
--- a/QTLtoolsv1.3_Dockerfile/Dockerfile
+++ b/QTLtoolsv1.3_Dockerfile/Dockerfile
@@ -4,7 +4,7 @@
 # Based on ubuntu
 ###############################################################
 
-FROM ubuntu:latest
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Using the latest ubuntu version causes that the curl version is 8.x. However, some of the tools to be installed require curl to be version 7.* and > 7.22, so we should fix the ubuntu version